### PR TITLE
Set tcril-engineering as the owner of this repo

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: xblock 
   lifecycle: unmaintained
-  owner: tcril-staff
+  owner: tcril-engineering


### PR DESCRIPTION
@e0d tcril-staff is the parent team to tcril-engineering, and includes Michelle & Jenna. Setting the owner of the repo to be just the engineering team. Also, this matches the rest of ownership in Backstage for our repos.