### PR TITLE
Update upgrade-python-requirements.yml schedule.

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Python Requirements
 
 on:
   schedule:
-    - cron: "30 0 * * 5"
+    - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Run it on midnight UTC every Sunday.  This means it ready for review on Monday like all the other Axim maintained repositories.