### PR TITLE
fix: add long description

### DIFF
--- a/invideoquiz/__init__.py
+++ b/invideoquiz/__init__.py
@@ -3,4 +3,4 @@ Runtime will load the XBlock class from here.
 """
 from .invideoquiz import InVideoQuizXBlock
 
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup(
     name='invideoquiz-xblock',
     version=VERSION,
     description='Helper XBlock to locate CAPA problems within videos.',
+    long_description='Helper XBlock to locate CAPA problems within videos.',
     license='AGPL v3',
     packages=[
         'invideoquiz',


### PR DESCRIPTION
Description:

In this PR added a long description for Pypi.
The test case failed with the following error after pushing the code on the master.

https://github.com/openedx/xblock-in-video-quiz/actions/runs/5750141691/job/15586311961

`ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.   `