### PR TITLE
Support backward compatibility for Quince earlier releases

### DIFF
--- a/invideoquiz/__init__.py
+++ b/invideoquiz/__init__.py
@@ -3,4 +3,4 @@ Runtime will load the XBlock class from here.
 """
 from .invideoquiz import InVideoQuizXBlock
 
-__version__ = '1.3.1'
+__version__ = '1.4.0'

--- a/invideoquiz/invideoquiz.py
+++ b/invideoquiz/invideoquiz.py
@@ -12,7 +12,12 @@ from xblock.fields import Scope
 from xblock.fields import String
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
-from xblock.utils.studio_editable import StudioEditableXBlockMixin
+try:
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin
+except ModuleNotFoundError:
+    # For backward compatibility with releases older than Quince.
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
+
 
 from .utils import _
 


### PR DESCRIPTION
- ticket: https://github.com/openedx/xblock-in-video-quiz/issues/148
- Support backward compatibility for Quince earlier releases
- Update release version