### PR TITLE
208: Replace pkg_resourse with importlib

### DIFF
--- a/invideoquiz/__init__.py
+++ b/invideoquiz/__init__.py
@@ -3,4 +3,4 @@ Runtime will load the XBlock class from here.
 """
 from .invideoquiz import InVideoQuizXBlock
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/invideoquiz/invideoquiz.py
+++ b/invideoquiz/invideoquiz.py
@@ -6,26 +6,29 @@ videos at specific time points.
 import json
 import os
 
-import pkg_resources
-
 from xblock.core import XBlock
 from xblock.fields import Scope
 from xblock.fields import String
+from xblock.validation import ValidationMessage
 
 try:
     from web_fragments.fragment import Fragment
 except ImportError:
     # For backward compatibility with quince and earlier.
     from xblock.fragment import Fragment
-from xblock.validation import ValidationMessage
+
 try:
     from xblock.utils.studio_editable import StudioEditableXBlockMixin
+    from xblock.utils.resources import ResourceLoader
 except ModuleNotFoundError:
     # For backward compatibility with releases older than Quince.
     from xblockutils.studio_editable import StudioEditableXBlockMixin
+    from xblockutils.resources import ResourceLoader
 
 
 from .utils import _
+
+resource_loader = ResourceLoader(__name__)
 
 
 def get_resource_string(path):
@@ -33,8 +36,7 @@ def get_resource_string(path):
     Retrieve string contents for the file path
     """
     path = os.path.join('public', path)
-    resource_string = pkg_resources.resource_string(__name__, path)
-    return resource_string.decode('utf8')
+    return resource_loader.load_unicode(path)
 
 
 class InVideoQuizXBlock(StudioEditableXBlockMixin, XBlock):


### PR DESCRIPTION
resolves https://github.com/openedx/xblock-in-video-quiz/issues/208

- Ensured xblock >= 5.0.0
- Test cases passing
- In Video Quiz working with edx-platform (tutor instance)
- pkg_resource removed

**CMS View**

<img width="1584" alt="Screenshot 2024-09-09 at 11 39 56 AM" src="https://github.com/user-attachments/assets/f18cff1d-065c-4931-a12c-050c0c06687c">



**LMS View**

<img width="981" alt="Screenshot 2024-09-09 at 12 00 28 PM" src="https://github.com/user-attachments/assets/4f9a692f-93e6-45b0-b114-f14a1e73a61c">

